### PR TITLE
Add dependabot config for monthly grouped bundler updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: bundler
+    directory: /
+    schedule:
+      interval: monthly
+    groups:
+      bundler:
+        patterns:
+          - "*"


### PR DESCRIPTION
Adds `.github/dependabot.yml` to re-enable ongoing dependabot version updates (previously only security updates were active, with no config file).

- Ecosystem: bundler, monthly
- All gems grouped into a single PR so interdependent bumps (e.g. nokogiri/loofah/rails-html-sanitizer) resolve together instead of conflicting as separate PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)