### PR TITLE
Add Dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,18 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable auto-merge
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
Enables GitHub native auto-merge on Dependabot PRs so they merge automatically once required CI checks pass. Uses the pull_request trigger per GitHub's recommended pattern; the permissions block elevates the otherwise read-only Dependabot token. Merges via --merge (repo permits merge commits only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)